### PR TITLE
Update test_SeqIO_online.py

### DIFF
--- a/Tests/test_SeqIO_online.py
+++ b/Tests/test_SeqIO_online.py
@@ -102,12 +102,19 @@ class UniProtTests(unittest.TestCase):
     def test_search(self):
         """UniPort.search("O48109")"""
         identifier = "O48109"
-        handle = UniProt.search(identifier, columns=("organism",))
-        self.assertEqual(handle.read(),
-                         "Organism\nPython regius (Ball python) (Boa regia)\n")
         handle = UniProt.search(identifier, output_format="fasta")
-        self.assertEqual(handle.readline().split("|")[1],
-                         identifier)
+        records = list(SeqIO.parse(handle, "fasta"))
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0].id, "sp|O48109|CYB_PYTRG")
+        self.assertEqual(len(records[0]), 371)
+        self.assertEqual(seguid(records[0]), "/lZIKaiUBqo5Tsx44ifwT0ay8U4")
+
+        handle = search(identifier, output_format="xml")
+        records = list(SeqIO.parse(handle, "uniprot-xml"))
+        self.assertEqual(len(records), 1)
+        self.assertEqual(len(records[0]), 371)
+        self.assertEqual(records[0].id, identifier)
+        self.assertEqual(seguid(records[0].seq), "Own5zJR+CD+Oas6vplJmN0XT+80")
 
 if __name__ == "__main__":
     runner = unittest.TextTestRunner(verbosity=2)


### PR DESCRIPTION
Changed tests to assess the parsing of the sequence files returned by UniProt.search

This pull request addresses issue #...

<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [X] I have read the ``CONTRIBUTING.rst`` file and understand that AppVeyor and
TravisCI will be used to confirm the Biopython unit tests and ``flake8`` style
checks pass with these changes.

- [ ] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
